### PR TITLE
Fixed broken ghlabs link, added instructions for external access

### DIFF
--- a/content/lab/l1/index.pl.md
+++ b/content/lab/l1/index.pl.md
@@ -224,5 +224,11 @@ git push origin main
 ```
 
 #### 4. Połączenie z systemem wydziałowym
-Aby połączyć się z naszym systemem udostępniającym repozytoria, z sieci wydziałowej wejdź na stronę [ghlabs](ghlabs.mini.pw.edu.pl) i połącz swoje konto na Githubie z kontem USOS.
+Aby połączyć się z naszym systemem udostępniającym repozytoria, z sieci wydziałowej wejdź na stronę [ghlabs](https://ghlabs.mini.pw.edu.pl/) i połącz swoje konto GitHub z kontem USOS.
 Dzięki temu w trakcie laboratoriów ocenianych uzyskasz dostęp do repozytorium na Twoje rozwiązanie.
+
+Aby uzyskać dostęp do systemu spoza sieci wydziałowej, najprostszym sposobem jest dodać do pliku `/etc/hosts` (na Windowsie: `%systemroot%\System32\Drivers\etc\hosts`) poniższy wpis:
+```
+194.29.178.38 ghlabs.mini.pw.edu.pl
+```
+Po dodaniu takiego wpisu, wyżej wspomniana strona powinna się normalnie otwierać.


### PR DESCRIPTION
Link do `ghlabs.mini.pw.edu.pl` był traktowany jako względna ścieżka i tym samym interpretowany jako `https://cpp.mini.pw.edu.pl/lab/l1/ghlabs.mini.pw.edu.pl`.

PR zawiera też propozycje instrukcji jak dostać się do tej strony spoza sieci wydziałowej. Być może jest to jednak miecz obusieczny, bo gdyby kiedyś wpis `ghlabs.mini.pw.edu.pl` zaistniał w zewnętrznym DNSie, ale z innym adresem IP (narazie jest taki sam jak głównej strony `mini.pw.edu.pl`), to studenci którzy rzadko edytują swój plik `/etc/hosts` mogą mieć trudność dociec do źródła problemu. Z drugiej strony taka instrukcja wydaje się jednak użyteczna.