### PR TITLE
W2 int --> vec

### DIFF
--- a/content/wyk/w2/index.pl.md
+++ b/content/wyk/w2/index.pl.md
@@ -91,7 +91,7 @@ int main()
 
     std::cout << "sizeof(c) = " << sizeof(c) << ", alignof(char) = " << alignof(char) << ", &c = " << (void*)&c << '\n';
     std::cout << "sizeof(x) = " << sizeof(x) << ", alignof(int) = " << alignof(int) << ", &x = " << &x << '\n';
-    std::cout << "sizeof(vec) = " << sizeof(x) << ", alignof(vector<int>) = " << alignof(int) << ", &vec = " << &vec <<'\n';
+    std::cout << "sizeof(vec) = " << sizeof(vec) << ", alignof(vector<int>) = " << alignof(vec) << ", &vec = " << &vec <<'\n';
 
     Point p = {1, 2};
 


### PR DESCRIPTION
Poprawka prawdopodobnej literówki w W2 przy pokazywaniu rozmiaru i alignu std::vector<int> -- czytaliśmy inta a nie wektor. Trzebaby pewnie jeszcze zmienić kod pliku, ale nie wiem jak to wrzucić w jednym commicie :<